### PR TITLE
Stop Propagation in Faram

### DIFF
--- a/components/Input/Faram/index.js
+++ b/components/Input/Faram/index.js
@@ -117,6 +117,7 @@ export default class Faram extends React.PureComponent {
 
     handleSubmitClick = (e) => {
         e.preventDefault();
+        e.stopPropagation();
         this.submit();
 
         // NOTE: Returning false will not submit the form & redirect


### PR DESCRIPTION
* Avoid `Submit` in Parent Faram When Children Faram `Submit` is triggered.