### PR TITLE
Add setDefault to immutability helper

### DIFF
--- a/utils/immutable-update.js
+++ b/utils/immutable-update.js
@@ -92,6 +92,13 @@ update.extend('$setIfDefined', (value, original) => {
     return value;
 });
 
+update.extend('$setDefault', (value, original) => {
+    if (original === undefined) {
+        return value;
+    }
+    return original;
+});
+
 update.extend('$mergeIfDefined', (obj, original) => {
     const copy = { ...original };
     Object.keys(obj).forEach((key) => {


### PR DESCRIPTION
`$setDefault` sets a value only if it is not already defined.

```js
// Use:
update(initialValue, {
    options: { $auto: {
        separator: { $setDefault: ',' },
    } },
});
```